### PR TITLE
Update test-and-release.yml - add node 20 tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
           lint: true
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         #node-version: [14.x, 16.x]
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Node 20 has been released as current node release. So all adapters should be tested with nodejs 20 too.

If your adapetr fails on nodejs 20 its OK to disable node 20 tests for now bute create a issue and try to fix the problem as soon as your time allows.